### PR TITLE
Handle `extends` option correctly in when calling `tslint`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 npm-debug.log
 tmp/
+yarn.lock
 tests/fixtures/output.txt

--- a/tests/fixtures/errorFiles/errorFile1.ts
+++ b/tests/fixtures/errorFiles/errorFile1.ts
@@ -1,1 +1,1 @@
-var Xx = "abcd";
+var Xx = "abcd"; 

--- a/tests/fixtures/lintConfig/extends-format.json
+++ b/tests/fixtures/lintConfig/extends-format.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tslint:recommended"
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,36 +38,6 @@ describe('broccoli-tslinter', function() {
     assert.throws(willThrow);
   });
 
-  it('should throw error during parsing of configuration file', function() {
-    var willThrow = function() {
-      var node = new TSLint('./tests/fixtures/errorFiles', {
-        logError: function(message) {
-          loggerOutput.push(message)
-        },
-        configuration: './tests/fixtures/lintConfig/parse-error.json'
-      });
-      builder = new broccoli.Builder(node);
-      return builder.build();
-    };
-
-    assert.throws(willThrow);
-  });
-
-  it('should throw error when configuration file does not follow format', function() {
-    var willThrow = function() {
-      var node = new TSLint('./tests/fixtures/errorFiles', {
-        logError: function(message) {
-          loggerOutput.push(message)
-        },
-        configuration: './tests/fixtures/lintConfig/incorrect-format.json'
-      });
-      builder = new broccoli.Builder(node);
-      return builder.build();
-    };
-
-    assert.throws(willThrow);
-  });
-
   it('linting correct file should result in no lint errors', function() {
     var node = new TSLint('./tests/fixtures/lintedFiles', {
       logError: function(message) {
@@ -85,6 +55,19 @@ describe('broccoli-tslinter', function() {
       logError: function(message) {
         loggerOutput.push(message);
       }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function() {
+      assert.notEqual(loggerOutput.length, 0, 'Errors should be seen for linted files');
+    });
+  });
+
+  it('linting error files with extends format should result in lint errors', function() {
+    var node = new TSLint('./tests/fixtures/errorFiles', {
+      logError: function(message) {
+        loggerOutput.push(message);
+      },
+      configuration: './tests/fixtures/lintConfig/extends-format.json'
     });
     builder = new broccoli.Builder(node);
     return builder.build().then(function() {


### PR DESCRIPTION
Before calling the tslint linter, we need to call `findConfiguration` in order for `extends` to be resolved.

Addresses: https://github.com/kratiahuja/broccoli-tslinter/issues/9
cc: @turbo87