### PR TITLE
Rename targetExtension to be a js file

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ Default: **uses the file tslint.json (in the root directory of your project)**
 
 Specify the path of the file where the detailed linting results will be present.
 
-Default: **undefined**
+Default: **lint-test.js**
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ TSLint.prototype = Object.create(Filter.prototype);
 TSLint.prototype.constructor = TSLint;
 // only touch typescript files
 TSLint.prototype.extensions = ['ts'];
-TSLint.prototype.targetExtension = 'tslint.ts';
+TSLint.prototype.targetExtension = 'lint-test.js';
 
 TSLint.prototype.build = function () {
   this.totalFiles = 0;

--- a/tests/index.js
+++ b/tests/index.js
@@ -101,7 +101,7 @@ describe('broccoli-tslinter', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(results) {
       var dir = results.directory;
-      var testGenerated = readFile(dir + '/errorFile1.tslint.ts');
+      var testGenerated = readFile(dir + '/errorFile1.lint-test.js');
       assert.notEqual(testGenerated.indexOf("QUnit.test(\'errorFile1.ts should pass tslint\'"), -1, 'Test should be generated');
       assert.notEqual(loggerOutput.length, 0, 'Errors should be seen for linted files');
     });
@@ -117,7 +117,7 @@ describe('broccoli-tslinter', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(results) {
       var dir = results.directory;
-      var testGenerated = readFile(dir + '/errorFile1.tslint.ts');
+      var testGenerated = readFile(dir + '/errorFile1.lint-test.js');
       assert.equal(testGenerated.indexOf("QUnit.test(\'errorFile1.ts should pass tslint\'"), -1, 'Test should not be generated');
       assert.notEqual(loggerOutput.length, 0, 'Errors should be seen for linted files');
     });
@@ -133,7 +133,7 @@ describe('broccoli-tslinter', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(results) {
       var dir = results.directory;
-      var testGenerated = readFile(dir + '/errorFile2.tslint.ts');
+      var testGenerated = readFile(dir + '/errorFile2.lint-test.js');
       assert.notEqual(testGenerated.indexOf("QUnit.test(\'errorFile2.ts should pass tslint\'"), -1, 'Test should be generated');
       assert.notEqual(testGenerated.indexOf("assert.ok(false, \'errorFile2.ts should pass tslint"), -1, 'Generated test should not pass');
       assert.notEqual(loggerOutput.length, 0, 'Errors should be seen for linted files');
@@ -152,7 +152,7 @@ describe('broccoli-tslinter', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(results) {
       var dir = results.directory;
-      var testGenerated = readFile(dir + '/errorFile1.tslint.ts');
+      var testGenerated = readFile(dir + '/errorFile1.lint-test.js');
       assert.notEqual(testGenerated.indexOf("FOO IS GENERATED"), -1, 'Test should not be generated');
       assert.notEqual(loggerOutput.length, 0, 'Errors should be seen for linted files');
     });


### PR DESCRIPTION
Typically the output of tslint contains Qunit tests that are purely JS content. Rename tslint.ts to lint-test.js so that folks using the plugin don't need to merge *.ts files in their broccoli output.

Resolves #13 

cc: @rwjblue 