### PR TITLE
Include rule name in error report

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,24 +93,30 @@ TSLint.prototype.processString = function(content, relativePath) {
   this.totalFiles++;
 
   var passed = result.errorCount === 0;
+  var errors = [];
   if (!passed) {
     // error is seen
     this.errorCount += result.errorCount;
 
-    result.output.split('\n').forEach(function (line) {
-      this.logError(line);
-    }, this);
+    errors = result.failures.map((failure) => {
+      var position = failure.startPosition.lineAndCharacter;
+      var line = position.line + 1;
+      var character = position.character + 1;
+      return `${failure.ruleSeverity.toUpperCase()}: ${failure.fileName}[${line}, ${character}]: ${failure.failure} (${failure.ruleName})`;
+    });
+
+    errors.forEach((line) => this.logError(line));
   }
 
   var output = '';
   if (!this.options.disableTestGenerator) {
-    output = this.testGenerator(relativePath, passed, result.output)
+    output = this.testGenerator(relativePath, passed, errors.join('\n'))
   }
 
   return {
     output: output,
     didPass: passed,
-    errors: result.output
+    errors: errors.join('\n')
   }
 };
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,6 +63,18 @@ describe('broccoli-tslinter', function() {
     });
   });
 
+  it('linting errors should contain violated rule name', function() {
+    var node = new TSLint('./tests/fixtures/errorFiles', {
+      logError: function(message) {
+        loggerOutput.push(message);
+      }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function() {
+      assert.include(loggerOutput.join('\n'), '(no-trailing-whitespace)', 'Rule name should be reported');
+    });
+  });
+
   it('linting error files with extends format should result in lint errors', function() {
     var node = new TSLint('./tests/fixtures/errorFiles', {
       logError: function(message) {


### PR DESCRIPTION
This PR adds the violated rule name in brackets at the end of the error report to resolve the problem reported in https://github.com/t-sauer/ember-cli-tslint/issues/7