### PR TITLE
Fix aot-test-generators usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ TSLint.prototype.testGenerator = function(relativePath, passed, errors) {
     var generatorName = this.options.testGenerator || 'qunit';
     var output = testGenerators[generatorName].suiteHeader('TSLint - ' + path.dirname(relativePath));
     output += testGenerators[generatorName].test(relativePath + ' should pass tslint', !!passed, relativePath + ' should pass tslint.' + errors);
+    output += testGenerators[generatorName].suiteFooter();
 
     return output;
   }


### PR DESCRIPTION
The test generated are missing the ending bracket:
```javascript
describe('TSLint - .', function() {
  it('errorFile1.ts should pass tslint', function() {
    // test failed
    var error = new chai.AssertionError('errorFile1.ts should pass tslint.\\nERROR: errorFile1.ts[1, 17]: trailing whitespace (no-trailing-whitespace)');
    error.stack = undefined;
    throw error;
  });
```

it should be:
```javascript
describe('TSLint - .', function() {
  it('errorFile1.ts should pass tslint', function() {
    // test failed
    var error = new chai.AssertionError('errorFile1.ts should pass tslint.\\nERROR: errorFile1.ts[1, 17]: trailing whitespace (no-trailing-whitespace)');
    error.stack = undefined;
    throw error;
  });
});
```